### PR TITLE
fix: use array args when calling DeleteSubdomain

### DIFF
--- a/src/commands/sites.js
+++ b/src/commands/sites.js
@@ -121,7 +121,7 @@ export async function infoSite(args = []) {
         }
     
         const data = await response.json();
-        const result = await deleteSubdomain(uuid);
+        const result = await deleteSubdomain([uuid]);
         if (result){
             // check if data is empty object
             if (Object.keys(data).length === 0){
@@ -183,7 +183,7 @@ export async function infoSite(args = []) {
                 } else {
                     console.log(chalk.yellow(`However, It's linked to different directory at: ${subdomainObj.root_dir?.path}`));
                     console.log(chalk.cyan(`We'll try to unlink this subdomain from that directory...`));
-                    const result = await deleteSubdomain(subdomainObj?.uid);
+                    const result = await deleteSubdomain([subdomainObj?.uid]);
                     if (result) {
                         console.log(chalk.green('Looks like this subdomain is free again, please try again.'));
                         return;


### PR DESCRIPTION
There were two possible ways to fix this: change the calls (what this commit does) or change the deleteSubdomain function to use the rest operator.

At first it looked like the spread operator was the correct change because that makes only one line of code incorrect vs two, however it was then realized that functions like `deleteSubdomain` adhere to an implied interface where the first argument to the function is always a list of command arguments, so this solution was picked instead.